### PR TITLE
Fix: Directory permissions for rootless Podman compatibility

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -26,10 +26,6 @@ jobs:
           DEFAULT_BRANCH: test
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: true
-          # Enable specific linters
-          VALIDATE_YAML: true
-          VALIDATE_ANSIBLE: true
-          VALIDATE_JSON: true
-          # Disable linters handled by dedicated workflows
+          # Disable linters handled by dedicated workflows or not needed
           VALIDATE_MARKDOWN: false
           VALIDATE_BASH: false

--- a/manage-svc.sh
+++ b/manage-svc.sh
@@ -351,7 +351,8 @@ if [[ "$ACTION" == "prepare" ]] || [[ "$ACTION" == "deploy" ]]; then
     NEED_SUDO=true
 elif [[ "$ACTION" == "remove" ]]; then
     # Check if service has delete_data=true (may need sudo for container-owned files)
-    if ansible-inventory -i "${INVENTORY}" --host "${TARGET_HOST}" --yaml 2>/dev/null | grep -q "delete_data.*true"; then
+    # Check both inventory variables and environment variable
+    if [[ "${DELETE_DATA}" == "true" ]] || ansible-inventory -i "${INVENTORY}" --host "${TARGET_HOST}" --yaml 2>/dev/null | grep -q "delete_data.*true"; then
         NEED_SUDO=true
     fi
 fi

--- a/roles/_base/tasks/cleanup.yml
+++ b/roles/_base/tasks/cleanup.yml
@@ -56,7 +56,6 @@
 
 - name: Remove all traces
   when: service_state == 'absent' and (service_properties.delete_data | bool)
-  become: true
   block:
     # ................................
     - name: Remove configuration

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -83,7 +83,7 @@ service_properties:
     - "{{elasticsearch_image}}"
     - "{{elasticsearch_elasticvue_image}}"
   dirs:
-    - { path: "", mode: "0750" }
+    - { path: "", mode: "0755" }
     - { path: "config", mode: "0700" }
     - { path: "data", mode: "0700" }
     - { path: "logs", mode: "0700" }

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -18,12 +18,12 @@ gitea_data_dir: "{{ real_user_dir }}/gitea-data"
 # Admin credentials
 gitea_admin_user: "gitea_admin"
 gitea_admin_password: "{{lookup('env', 'GITEA_ADMIN_PASSWORD', default='changeme')}}"
-gitea_admin_email: "admin@{{domain}}"  # noqa yaml[line-length]
+gitea_admin_email: "admin@{{domain}}" # noqa yaml[line-length]
 
 # Service naming and URL construction
-gitea_svc_name: "gitea"  # Override per host in inventory
+gitea_svc_name: "gitea" # Override per host in inventory
 gitea_fqdn: "{{gitea_svc_name}}.{{domain}}"
-gitea_external_port: 8080  # Port users access through Traefik
+gitea_external_port: 8080 # Port users access through Traefik
 gitea_external_url: "https://{{gitea_fqdn}}:{{gitea_external_port}}"
 
 # Traefik integration
@@ -31,7 +31,7 @@ gitea_enable_traefik: true
 
 # Application settings
 gitea_app_name: "Gitea"
-gitea_domain: "{{gitea_fqdn}}"  # For backward compatibility
+gitea_domain: "{{gitea_fqdn}}" # For backward compatibility
 gitea_root_url: "{{gitea_external_url}}"
 gitea_disable_registration: false
 gitea_require_signin: true
@@ -60,9 +60,9 @@ service_properties:
   delete_images: "{{lookup('env', 'DELETE_IMAGES') | default(false) | bool}}"
   container_image: "{{gitea_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
-    - {path: "data/gitea", mode: "0750"}
-    - {path: "data/git", mode: "0750"}
-    - {path: "logs", mode: "0750"}
+    - { path: "", mode: "0755" }
+    - { path: "config", mode: "0755" }
+    - { path: "data", mode: "0755" }
+    - { path: "data/gitea", mode: "0755" }
+    - { path: "data/git", mode: "0755" }
+    - { path: "logs", mode: "0755" }

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -72,12 +72,12 @@ service_properties:
   delete_images: "{{lookup('env', 'DELETE_IMAGES') | default(false) | bool}}"
   container_image: "{{grafana_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
-    - {path: "logs", mode: "0750"}
-    - {path: "plugins", mode: "0750"}
-    - {path: "provisioning", mode: "0750"}
-    - {path: "provisioning/dashboards", mode: "0750"}
-    - {path: "provisioning/datasources", mode: "0750"}
-    - {path: "provisioning/notifiers", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "data", mode: "0755"}
+    - {path: "logs", mode: "0755"}
+    - {path: "plugins", mode: "0755"}
+    - {path: "provisioning", mode: "0755"}
+    - {path: "provisioning/dashboards", mode: "0755"}
+    - {path: "provisioning/datasources", mode: "0755"}
+    - {path: "provisioning/notifiers", mode: "0755"}

--- a/roles/hashivault/defaults/main.yml
+++ b/roles/hashivault/defaults/main.yml
@@ -70,8 +70,8 @@ service_properties:
   delete_images: "{{lookup('env', 'DELETE_IMAGES') | default(false) | bool}}"
   container_image: "{{vault_image}}"
   dirs:
-    - { path: "", mode: "0750" }
-    - { path: "config", mode: "0750" }
-    - { path: "data", mode: "0750" }
-    - { path: "logs", mode: "0750" }
-    - { path: "tls", mode: "0750" }
+    - { path: "", mode: "0755" }
+    - { path: "config", mode: "0755" }
+    - { path: "data", mode: "0755" }
+    - { path: "logs", mode: "0755" }
+    - { path: "tls", mode: "0755" }

--- a/roles/influxdb3/defaults/main.yml
+++ b/roles/influxdb3/defaults/main.yml
@@ -61,8 +61,8 @@ service_properties:
   delete_images: "{{lookup('env', 'DELETE_IMAGES') | default(false) | bool}}"
   container_image: "{{influxdb3_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
-    - {path: "plugins", mode: "0750"}
-    - {path: "secrets", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "data", mode: "0755"}
+    - {path: "plugins", mode: "0755"}
+    - {path: "secrets", mode: "0755"}

--- a/roles/mattermost/defaults/main.yml
+++ b/roles/mattermost/defaults/main.yml
@@ -75,12 +75,12 @@ service_properties:
     - "{{mattermost_image}}"
     - "{{mattermost_postgres_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
-    - {path: "logs", mode: "0750"}  # Allow container to create and manage logs
-    - {path: "plugins", mode: "0750"}
-    - {path: "client", mode: "0750"}
-    - {path: "client/plugins", mode: "0750"}
-    - {path: "bleve-indexes", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "data", mode: "0755"}
+    - {path: "logs", mode: "0755"}  # Allow container to create and manage logs
+    - {path: "plugins", mode: "0755"}
+    - {path: "client", mode: "0755"}
+    - {path: "client/plugins", mode: "0755"}
+    - {path: "bleve-indexes", mode: "0755"}
     - {path: "postgres", mode: "0755"}  # PostgreSQL will manage its own permissions

--- a/roles/minio/defaults/main.yml
+++ b/roles/minio/defaults/main.yml
@@ -61,7 +61,7 @@ service_properties:
   delete_images: "{{lookup('env', 'DELETE_IMAGES') | default(false) | bool}}"
   container_image: "{{minio_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
-    - {path: "tls", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "data", mode: "0755"}
+    - {path: "tls", mode: "0755"}

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -43,10 +43,10 @@ service_properties:
     - "{{ mongodb_image }}"
     - "{{ mongodb_express_image }}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
-    - {path: "logs", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "data", mode: "0755"}
+    - {path: "logs", mode: "0755"}
   ports:
     - "127.0.0.1:{{ mongodb_port }}:27017"
     - "127.0.0.1:{{ mongodb_gui_port }}:8081"

--- a/roles/obsidian/defaults/main.yml
+++ b/roles/obsidian/defaults/main.yml
@@ -38,9 +38,9 @@ service_properties:
   container_images:
     - "{{ obsidian_image }}"
   dirs:
-    - { path: "", mode: "0750" }
-    - { path: "config", mode: "0750" }
-    - { path: "vaults", mode: "0750" }
+    - { path: "", mode: "0755" }
+    - { path: "config", mode: "0755" }
+    - { path: "vaults", mode: "0755" }
   ports:
     - "127.0.0.1:{{ obsidian_port }}:3000"
     - "127.0.0.1:{{ obsidian_https_port }}:3001"

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -65,9 +65,9 @@ service_properties:
     - "{{redis_image}}"
     - "{{redis_commander_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "data", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "data", mode: "0755"}
   ports:
     - "127.0.0.1:{{redis_port}}:6379"
     - "127.0.0.1:{{redis_gui_port}}:8081"

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -71,7 +71,7 @@ service_properties:
   delete_images: "{{lookup('env', 'DELETE_IMAGES') | default(false) | bool}}"
   container_image: "{{traefik_image}}"
   dirs:
-    - {path: "", mode: "0750"}
-    - {path: "config", mode: "0750"}
-    - {path: "acme", mode: "0750"}
-    - {path: "logs", mode: "0750"}
+    - {path: "", mode: "0755"}
+    - {path: "config", mode: "0755"}
+    - {path: "acme", mode: "0755"}
+    - {path: "logs", mode: "0755"}


### PR DESCRIPTION
## Summary

This PR fixes directory permissions across all service roles to be compatible with rootless Podman's `:U` mount flag for automatic uid/gid remapping.

## Changes

### Permission Updates (0750 → 0755)
Updated 11 service roles to use `0755` permissions for directories that use the `:U` mount flag:
- ✓ elasticsearch (root dir only, config/data/logs remain 0700)
- ✓ grafana (all 9 directories)
- ✓ hashivault (all 5 directories)
- ✓ influxdb3 (all 5 directories)
- ✓ mattermost (all 9 directories)
- ✓ minio (all 4 directories)
- ✓ mongodb (all 4 directories)
- ✓ obsidian (all 3 directories)
- ✓ traefik (all 4 directories)
- ✓ gitea (all 6 directories)
- ✓ redis (all 3 directories)

### Infrastructure Improvements
- **Super-Linter workflow fix**: Removed conflicting VALIDATE_* settings (v4 doesn't support mixing include/exclude)
- **manage-svc.sh**: Added DELETE_DATA environment variable check for sudo detection
- **_base role**: Removed `become: true` from cleanup block (aligns with rootless principles)

## Why This Change?

The "other" execute bit (0755 vs 0750) is required for rootless Podman's XDG access mechanism to properly remap ownership when using the `:U` flag on volume mounts. Without this, containers fail to access mounted directories due to permission errors.

## Testing

✓ All CI checks passed
✓ Lint and Syntax Check passed
⏳ Super-Linter running (config fixed)

## Related Issues

Resolves the gitea deployment permission issue where `app.ini` was inaccessible due to incorrect directory permissions preventing the `:U` flag from working properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)